### PR TITLE
fix(asUncaughtError): fixed asUncaughtError's typings

### DIFF
--- a/src/utils/as-uncaught-error.ts
+++ b/src/utils/as-uncaught-error.ts
@@ -1,4 +1,4 @@
 import { Task, UncaughtError } from '../task';
-export function asUncaughtError (error: any): Task<never, UncaughtError> {
+export function asUncaughtError <T> (error: T): Task<never, UncaughtError> {
     return Task.reject(new UncaughtError(error));
 }


### PR DESCRIPTION
# Description

In certain configurations, `caseError(..., asUncagaughtError)` with previous typings (`asUncaughtError(err: any)`) would led to an incorrect `Task<..., {} | UncaughtError>`.