### PR TITLE
feat(UncaughtError): preserve original stack

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -6,6 +6,9 @@ export class UncaughtError extends Error {
 
     constructor (private error: any) {
         super('UncaughtError: ' + error.toString());
+
+        // Preserve original stack to ease debugging:
+        this.stack = error.stack;
     }
 }
 

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,7 +1,7 @@
+// Weird but I have to import "nothing" from "jest" to have the global jest functions  (describe, etc.) available
+import {} from 'jest';
 import { Task, UncaughtError } from '../src/task';
 import { assertFork, jestAssertNever, jestAssertUntypedNeverCalled } from './jest-helper';
-
-
 
 describe('Task', () => {
     describe('fork', () => {

--- a/test/uncaught-error.test.ts
+++ b/test/uncaught-error.test.ts
@@ -1,0 +1,38 @@
+// Weird but I have to import "nothing" from "jest" to have the global jest functions  (describe, etc.) available
+import {} from 'jest';
+import { UncaughtError } from '../src/task';
+
+describe('UncaughtError', () => {
+    // Maintains wrapped error's stack
+    describe('.message', () => {
+        it('should include the wrapped error\'s message', () => {
+            const originalErrorMsg = 'Buuuu!';
+            const wrappedError = new Error(originalErrorMsg);
+            expect(new UncaughtError(wrappedError).message).toMatch(originalErrorMsg);
+        });
+
+        it('should prepend "UncaughtError:"', () => {
+            const wrappedError = new Error('Buuuu!');
+            expect(new UncaughtError(wrappedError).message).toMatch(/^UncaughtError\:/);
+        });
+    });
+
+    describe('.stack', () => {
+        it('should mantain wrapped error\'s stack', () => {
+            // Throw an Error with an "interesting" stack
+            const foo = () => bar();
+            const bar = () => baz();
+            const baz = () => {
+                throw new Error('Buuuu!');
+            };
+
+            try {
+                foo();
+            }
+            catch (wrappedError) {
+                const uncaughtError = new UncaughtError(wrappedError);
+                expect(uncaughtError.stack).toBe(wrappedError.stack);
+            }
+        });
+    });
+});

--- a/test/utils/as-uncaught-error.test.ts
+++ b/test/utils/as-uncaught-error.test.ts
@@ -1,3 +1,5 @@
+// Weird but I have to import "nothing" from "jest" to have the global jest functions  (describe, etc.) available
+import {} from 'jest';
 import { Task, UncaughtError } from '../../src/task';
 import { asUncaughtError } from '../../src/utils/as-uncaught-error';
 import { assertFork, jestAssertNever, jestAssertUntypedNeverCalled } from '../jest-helper';


### PR DESCRIPTION
`UncaughtError` preserves the `.stack` of the _wrapped_ `Error` to ease debugging.